### PR TITLE
Removed the jq/install step, rely on the server to already have jq in…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             circleci config pack src/ > packed.yml
             circleci orb validate packed.yml --token ${CIRCLECI_API_KEY}
-            PUBLISH_MESSAGE=`circleci orb publish packed.yml circleci/jira@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} --token ${CIRCLECI_API_KEY}`
+            PUBLISH_MESSAGE=`circleci orb publish packed.yml wizehive/jira-nojq@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} --token ${CIRCLECI_API_KEY}`
             echo $PUBLISH_MESSAGE
             ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb `\(.*\)` was published.*/\1/p')
             echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: Test against published dev version using BATS
           command: |
-            export BATS_IMPORT_DEV_ORB="circleci/jira@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1}"
+            export BATS_IMPORT_DEV_ORB="wizehive/jira-nojq@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1}"
             bats tests
       - run:
           name: Publish Dev version to PR
@@ -74,7 +74,7 @@ jobs:
               echo "export PR_MESSAGE=\"BotComment: Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
               exit 0
             else
-              PUBLISH_MESSAGE=`circleci orb publish promote circleci/jira@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+              PUBLISH_MESSAGE=`circleci orb publish promote wizehive/jira-nojq@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
               echo $PUBLISH_MESSAGE
               ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
               echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -26,7 +26,6 @@ parameters:
     default: "[A-Z]{2,30}-[0-9]+"
     type: string
 steps:
-  - jq/install
   
   - run:
       name: JIRA - Setting Failure Condition

--- a/src/examples/basic_build.yml
+++ b/src/examples/basic_build.yml
@@ -2,7 +2,7 @@ description: Notify jira on single job
 usage:
   version: 2.1
   orbs: 
-    jira: circleci/jira@x.y.z
+    jira: wizehive/jira-nojq@x.y.z
 
   workflows:
     build:

--- a/src/examples/full_workflow.yml
+++ b/src/examples/full_workflow.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
 
   orbs:
-    jira: circleci/jira@x.y.z
+    jira: wizehive/jira-nojq@x.y.z
 
   workflows:
     build-deploy:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -9,5 +9,3 @@ description: >
 
   Orb source code available here: https://github.com/CircleCI-Public/jira-connect-orb
   
-orbs:
-  jq: circleci/jq@1.8.0


### PR DESCRIPTION
…stalled properly. The jq install was causing issues with the circleci builds that were using jira/notify due to a compilation issue with the code.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ X] All new jobs, commands, executors, parameters have descriptions
- [ X] Examples have been added for any significant new features
- [ X] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
